### PR TITLE
Add offline blast protection and territory restrictions

### DIFF
--- a/src/main/kotlin/com/dansplugins/factionsystem/MedievalFactions.kt
+++ b/src/main/kotlin/com/dansplugins/factionsystem/MedievalFactions.kt
@@ -64,6 +64,8 @@ import com.dansplugins.factionsystem.listener.PlayerMoveListener
 import com.dansplugins.factionsystem.listener.PlayerQuitListener
 import com.dansplugins.factionsystem.listener.PlayerTeleportListener
 import com.dansplugins.factionsystem.listener.PotionSplashListener
+import com.dansplugins.factionsystem.listener.OfflineProtectionListener
+import com.dansplugins.factionsystem.listener.TerritoryRestrictionsListener
 import com.dansplugins.factionsystem.locks.JooqMfLockRepository
 import com.dansplugins.factionsystem.locks.MfLockRepository
 import com.dansplugins.factionsystem.locks.MfLockService
@@ -311,6 +313,17 @@ class MedievalFactions : JavaPlugin() {
             }
         }
 
+        if (config.getBoolean("offlineBlastProtection.enabled")) {
+            logger.info("Offline blast protection: enabled")
+        } else {
+            logger.info("Offline blast protection: disabled")
+        }
+        if (config.getBoolean("territoryRestrictions.enabled")) {
+            logger.info("Territory block restrictions: enabled")
+        } else {
+            logger.info("Territory block restrictions: disabled")
+        }
+
         registerListeners(
             AreaEffectCloudApplyListener(this),
             AsyncPlayerChatListener(this),
@@ -321,10 +334,12 @@ class MedievalFactions : JavaPlugin() {
             BlockPistonExtendListener(this),
             BlockPistonRetractListener(this),
             BlockPlaceListener(this),
+            TerritoryRestrictionsListener(this),
             CreatureSpawnListener(this),
             EntityDamageByEntityListener(this),
             EntityDamageListener(this),
             EntityExplodeListener(this),
+            OfflineProtectionListener(this),
             InventoryMoveItemListener(this),
             LingeringPotionSplashListener(this),
             PlayerBucketListener(this),

--- a/src/main/kotlin/com/dansplugins/factionsystem/claim/MfClaimService.kt
+++ b/src/main/kotlin/com/dansplugins/factionsystem/claim/MfClaimService.kt
@@ -46,6 +46,23 @@ class MfClaimService(private val plugin: MedievalFactions, private val repositor
     @JvmName("getClaimsByFactionId")
     fun getClaims(factionId: MfFactionId): List<MfClaimedChunk> = claims.filter { it.factionId == factionId }
 
+    @JvmName("isPlayerMemberOrAllyOfClaimedChunk")
+    fun isPlayerMemberOrAlly(playerId: MfPlayerId, claim: MfClaimedChunk, treatAlliesAsMembers: Boolean): Boolean {
+        val factionService = plugin.services.factionService
+        val playerFaction = factionService.getFaction(playerId) ?: return false
+        if (playerFaction.id == claim.factionId) {
+            return true
+        }
+        if (!treatAlliesAsMembers) {
+            return false
+        }
+        val relationshipService = plugin.services.factionRelationshipService
+        if (relationshipService.getAllies(claim.factionId).contains(playerFaction.id)) {
+            return true
+        }
+        return relationshipService.getAllies(playerFaction.id).contains(claim.factionId)
+    }
+
     @JvmName("isInteractionAllowedForPlayerInChunk")
     fun isInteractionAllowed(playerId: MfPlayerId, claim: MfClaimedChunk): Boolean {
         val factionService = plugin.services.factionService

--- a/src/main/kotlin/com/dansplugins/factionsystem/faction/MfFactionService.kt
+++ b/src/main/kotlin/com/dansplugins/factionsystem/faction/MfFactionService.kt
@@ -67,6 +67,14 @@ class MfFactionService(private val plugin: MedievalFactions, private val reposit
     @JvmName("getFactionByFactionId")
     fun getFaction(factionId: MfFactionId): MfFaction? = factionsById[factionId]
 
+    @JvmName("hasOnlineMemberByFactionId")
+    fun hasOnlineMember(factionId: MfFactionId): Boolean {
+        val faction = getFaction(factionId) ?: return false
+        return faction.members.any { member ->
+            member.playerId.toBukkitPlayer().player?.isOnline == true
+        }
+    }
+
     fun save(faction: MfFaction): Result4k<MfFaction, ServiceFailure> = resultFrom {
         val previousState = getFaction(faction.id)
         var factionToSave = faction

--- a/src/main/kotlin/com/dansplugins/factionsystem/listener/OfflineProtectionListener.kt
+++ b/src/main/kotlin/com/dansplugins/factionsystem/listener/OfflineProtectionListener.kt
@@ -1,0 +1,77 @@
+package com.dansplugins.factionsystem.listener
+
+import com.dansplugins.factionsystem.MedievalFactions
+import com.dansplugins.factionsystem.claim.MfClaimedChunk
+import com.dansplugins.factionsystem.faction.MfFactionId
+import org.bukkit.World
+import org.bukkit.block.Block
+import org.bukkit.event.EventHandler
+import org.bukkit.event.EventPriority
+import org.bukkit.event.Listener
+import org.bukkit.event.block.BlockExplodeEvent
+import org.bukkit.event.entity.EntityExplodeEvent
+
+class OfflineProtectionListener(private val plugin: MedievalFactions) : Listener {
+
+    @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
+    fun onEntityExplode(event: EntityExplodeEvent) {
+        handleExplosion(event.blockList(), event.location.world) {
+            event.blockList().clear()
+            event.isCancelled = true
+        }
+    }
+
+    @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
+    fun onBlockExplode(event: BlockExplodeEvent) {
+        handleExplosion(event.blockList(), event.block.world) {
+            event.blockList().clear()
+            event.isCancelled = true
+        }
+    }
+
+    private fun handleExplosion(blocks: MutableList<Block>, world: World?, cancel: () -> Unit) {
+        val config = plugin.config
+        if (!config.getBoolean("offlineBlastProtection.enabled")) {
+            return
+        }
+        if (world == null) {
+            return
+        }
+        val exemptWorlds = config.getStringList("offlineBlastProtection.exemptWorlds").map(String::lowercase)
+        if (exemptWorlds.contains(world.name.lowercase())) {
+            return
+        }
+        if (blocks.isEmpty()) {
+            return
+        }
+        val claimService = plugin.services.claimService
+        val allowWhenAnyMemberOnline = config.getBoolean("offlineBlastProtection.allowWhenAnyMemberOnline", true)
+        val factionsToProtect = mutableMapOf<MfFactionId, Boolean>()
+        val protectedBlocks = blocks.filter { block ->
+            val claim = claimService.getClaim(block.chunk) ?: return@filter false
+            shouldProtect(claim, allowWhenAnyMemberOnline, factionsToProtect)
+        }
+        if (protectedBlocks.isEmpty()) {
+            return
+        }
+        if (config.getBoolean("offlineBlastProtection.onlyBlockDamage", true)) {
+            blocks.removeAll(protectedBlocks.toSet())
+        } else {
+            cancel()
+        }
+    }
+
+    private fun shouldProtect(
+        claim: MfClaimedChunk,
+        allowWhenAnyMemberOnline: Boolean,
+        cache: MutableMap<MfFactionId, Boolean>
+    ): Boolean {
+        return cache.getOrPut(claim.factionId) {
+            if (!allowWhenAnyMemberOnline) {
+                return@getOrPut true
+            }
+            val factionService = plugin.services.factionService
+            !factionService.hasOnlineMember(claim.factionId)
+        }
+    }
+}

--- a/src/main/kotlin/com/dansplugins/factionsystem/listener/TerritoryRestrictionsListener.kt
+++ b/src/main/kotlin/com/dansplugins/factionsystem/listener/TerritoryRestrictionsListener.kt
@@ -1,0 +1,182 @@
+package com.dansplugins.factionsystem.listener
+
+import com.dansplugins.factionsystem.MedievalFactions
+import com.dansplugins.factionsystem.claim.MfClaimedChunk
+import com.dansplugins.factionsystem.player.MfPlayerId
+import org.bukkit.ChatColor
+import org.bukkit.Material
+import org.bukkit.entity.Player
+import org.bukkit.event.EventHandler
+import org.bukkit.event.EventPriority
+import org.bukkit.event.Listener
+import org.bukkit.event.block.BlockBreakEvent
+import org.bukkit.event.block.BlockPlaceEvent
+import org.bukkit.event.player.PlayerInteractEvent
+import org.bukkit.event.block.Action.RIGHT_CLICK_BLOCK
+
+class TerritoryRestrictionsListener(private val plugin: MedievalFactions) : Listener {
+
+    @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
+    fun onBlockPlace(event: BlockPlaceEvent) {
+        val restrictions = getRestrictions()
+        if (!restrictions.enabled) {
+            return
+        }
+        if (!restrictions.restrictedPlace.matches(event.block.type)) {
+            return
+        }
+        val player = event.player
+        if (hasBypass(player)) {
+            return
+        }
+        val claimService = plugin.services.claimService
+        val claim = claimService.getClaim(event.block.chunk)
+        if (!isPlayerAllowed(player, claim, restrictions.treatAlliesAsMembers)) {
+            event.isCancelled = true
+            sendMessage(player, restrictions.message)
+        }
+    }
+
+    @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
+    fun onBlockBreak(event: BlockBreakEvent) {
+        val restrictions = getRestrictions()
+        if (!restrictions.enabled) {
+            return
+        }
+        if (!restrictions.restrictedBreak.matches(event.block.type)) {
+            return
+        }
+        val player = event.player
+        if (hasBypass(player)) {
+            return
+        }
+        val claimService = plugin.services.claimService
+        val claim = claimService.getClaim(event.block.chunk)
+        if (!isPlayerAllowed(player, claim, restrictions.treatAlliesAsMembers)) {
+            event.isCancelled = true
+            sendMessage(player, restrictions.message)
+        }
+    }
+
+    @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
+    fun onPlayerInteract(event: PlayerInteractEvent) {
+        val restrictions = getRestrictions()
+        if (!restrictions.enabled) {
+            return
+        }
+        if (event.action != RIGHT_CLICK_BLOCK) {
+            return
+        }
+        val clickedBlock = event.clickedBlock ?: return
+        val material = clickedBlock.type
+        if (!restrictions.restrictedInteraction.matches(material)) {
+            return
+        }
+        if (restrictions.interactionWhitelist.matches(material)) {
+            return
+        }
+        val player = event.player
+        if (hasBypass(player)) {
+            return
+        }
+        val claimService = plugin.services.claimService
+        val claim = claimService.getClaim(clickedBlock.chunk)
+        if (!isPlayerAllowed(player, claim, restrictions.treatAlliesAsMembers)) {
+            event.isCancelled = true
+            sendMessage(player, restrictions.message)
+        }
+    }
+
+    private fun hasBypass(player: Player): Boolean {
+        if (player.hasPermission("medievalfactions.bypassrestrictions")) {
+            return true
+        }
+        val mfPlayer = plugin.services.playerService.getPlayer(player)
+        return mfPlayer?.isBypassEnabled == true && player.hasPermission("mf.bypass")
+    }
+
+    private fun isPlayerAllowed(player: Player, claim: MfClaimedChunk?, treatAlliesAsMembers: Boolean): Boolean {
+        if (claim == null) {
+            return false
+        }
+        val claimService = plugin.services.claimService
+        val playerId = MfPlayerId.fromBukkitPlayer(player)
+        return claimService.isPlayerMemberOrAlly(playerId, claim, treatAlliesAsMembers)
+    }
+
+    private fun sendMessage(player: Player, message: String) {
+        if (message.isNotBlank()) {
+            player.sendMessage(message)
+        }
+    }
+
+    private fun getRestrictions(): Restrictions {
+        val config = plugin.config
+        val message = ChatColor.translateAlternateColorCodes(
+            '&',
+            config.getString("territoryRestrictions.messages.notInOwnTerritory")
+                ?: "&cYou can only do that with this block inside your faction's territory."
+        )
+        return Restrictions(
+            enabled = config.getBoolean("territoryRestrictions.enabled"),
+            treatAlliesAsMembers = config.getBoolean("territoryRestrictions.treatAlliesAsMembers"),
+            restrictedPlace = parseMaterialMatcher("territoryRestrictions.restrictedPlace"),
+            restrictedBreak = parseMaterialMatcher("territoryRestrictions.restrictedBreak"),
+            interactionWhitelist = parseMaterialMatcher("territoryRestrictions.interactionWhitelist"),
+            message = message
+        )
+    }
+
+    private fun parseMaterialMatcher(path: String): MaterialMatcher {
+        val config = plugin.config
+        val exact = mutableSetOf<Material>()
+        val patterns = mutableSetOf<String>()
+        config.getStringList(path).forEach { entry ->
+            val value = entry.trim()
+            if (value.isEmpty()) {
+                return@forEach
+            }
+            val material = Material.matchMaterial(value, true)
+            if (material != null) {
+                exact += material
+            } else {
+                patterns += value.uppercase()
+            }
+        }
+        return MaterialMatcher(exact, patterns)
+    }
+
+    private data class Restrictions(
+        val enabled: Boolean,
+        val treatAlliesAsMembers: Boolean,
+        val restrictedPlace: MaterialMatcher,
+        val restrictedBreak: MaterialMatcher,
+        val interactionWhitelist: MaterialMatcher,
+        val message: String
+    ) {
+        val restrictedInteraction: MaterialMatcher = restrictedPlace + restrictedBreak
+    }
+
+    private data class MaterialMatcher(
+        val exact: Set<Material>,
+        val patterns: Set<String>
+    ) {
+        fun matches(material: Material): Boolean {
+            if (exact.contains(material)) {
+                return true
+            }
+            if (patterns.isEmpty()) {
+                return false
+            }
+            val name = material.name.uppercase()
+            return patterns.any { pattern -> name.contains(pattern) }
+        }
+
+        operator fun plus(other: MaterialMatcher): MaterialMatcher {
+            return MaterialMatcher(
+                (exact + other.exact).toSet(),
+                (patterns + other.patterns).toSet()
+            )
+        }
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -24,6 +24,32 @@ wilderness:
   break:
     prevent: false
     alert: true
+offlineBlastProtection:
+  enabled: true
+  onlyBlockDamage: true
+  exemptWorlds: []
+  allowWhenAnyMemberOnline: true
+territoryRestrictions:
+  enabled: true
+  treatAlliesAsMembers: false
+  restrictedPlace:
+    - TNT
+    - HOPPER
+    - BEACON
+    - ANVIL
+    - ENCHANTING_TABLE
+  restrictedBreak:
+    - BEACON
+    - ANVIL
+    - SPAWNER
+  interactionWhitelist:
+    - CHEST
+    - DOOR
+    - LEVER
+    - BUTTON
+    - FURNACE
+  messages:
+    notInOwnTerritory: "&cYou can only do that with this block inside your faction's territory."
 pvp:
   enabledForFactionlessPlayers: true
   warRequiredForPlayersOfDifferentFactions: true

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -313,6 +313,9 @@ permissions:
   mf.bypass:
     description: Allows bypassing faction protections
     default: op
+  medievalfactions.bypassrestrictions:
+    description: Allows bypassing territory block restrictions
+    default: op
   mf.chat:
     description: Allows using faction chat
     default: true


### PR DESCRIPTION
## Summary
- add configuration-backed offline blast protection that cancels or filters explosions in offline faction territory and announce feature state on startup
- introduce configurable territory block placement, breaking, and interaction restrictions with a bypass permission and listener enforcement
- extend claim and faction services plus default config values to support the new mechanics

## Testing
- ./gradlew test *(fails: Unsupported class file major version 65 in build environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e14c65231c8320a703d47ae389f9e8