### PR TITLE
Add main hand guard to territory restriction listener

### DIFF
--- a/src/main/kotlin/com/dansplugins/factionsystem/listener/TerritoryRestrictionsListener.kt
+++ b/src/main/kotlin/com/dansplugins/factionsystem/listener/TerritoryRestrictionsListener.kt
@@ -13,6 +13,7 @@ import org.bukkit.event.block.BlockBreakEvent
 import org.bukkit.event.block.BlockPlaceEvent
 import org.bukkit.event.player.PlayerInteractEvent
 import org.bukkit.event.block.Action.RIGHT_CLICK_BLOCK
+import org.bukkit.inventory.EquipmentSlot.HAND
 
 class TerritoryRestrictionsListener(private val plugin: MedievalFactions) : Listener {
 
@@ -65,6 +66,9 @@ class TerritoryRestrictionsListener(private val plugin: MedievalFactions) : List
             return
         }
         if (event.action != RIGHT_CLICK_BLOCK) {
+            return
+        }
+        if (event.hand != HAND) {
             return
         }
         val clickedBlock = event.clickedBlock ?: return


### PR DESCRIPTION
## Summary
- ensure the territory restriction listener only processes main-hand interactions
- align the listener behavior with PlayerInteractListener so restriction messages only trigger once

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1660db7c4832082c29fcebcb78922