### PR TITLE
Fix Mockito configuration for Java 21 tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,8 +61,8 @@ dependencies {
 
     // Use the Kotlin JUnit 5 integration.
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
-    testImplementation("org.mockito:mockito-core:4.0.0")
-    testImplementation("org.mockito:mockito-inline:4.0.0")
+    testImplementation("org.mockito:mockito-core:5.2.0")
+    testImplementation("org.mockito:mockito-inline:5.2.0")
 
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
@@ -92,6 +92,10 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
 
 tasks.named('check') {
     dependsOn 'installKotlinterPrePushHook'
+}
+
+tasks.withType(Test).configureEach {
+    jvmArgs('-Dnet.bytebuddy.experimental=true')
 }
 
 tasks.register('ktlintCheck') {

--- a/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
## Summary
- update Mockito test dependencies to 5.2.0 and enable ByteBuddy's experimental mode for Java 21 instrumentation
- add a Mockito inline mock maker configuration resource so Bukkit classes can be mocked in tests

## Testing
- ./gradlew test --no-daemon --console plain

------
https://chatgpt.com/codex/tasks/task_e_68e4004f88a483209fb2e924b7dcda0c